### PR TITLE
Add and implement set operations.

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -24,4 +24,15 @@ func TestCache(t *testing.T) {
 	assert.Equal(t, nil, con.Get("key"))
 
 	assert.False(t, con.Exists("key"))
+
+	// Sets
+	con.SetAdd("myset", "hello")
+	con.SetAdd("myset", "world")
+	assert.True(t, compareStringSets(con.SetMembers("myset"), []string{"hello", "world"}))
+	con.SetAdd("myset", "hello")
+	assert.True(t, compareStringSets(con.SetMembers("myset"), []string{"hello", "world"}))
+	con.SetAdd("myset", "hi")
+	assert.True(t, compareStringSets(con.SetMembers("myset"), []string{"hello", "world", "hi"}))
+	con.Delete("myset")
+	assert.True(t, con.SetMembers("myset") == nil)
 }

--- a/kvstores.go
+++ b/kvstores.go
@@ -12,4 +12,6 @@ type KVStoreConnection interface {
 	Flush() error
 	Exists(key string) bool
 	Set(key string, value interface{}) error
+	SetAdd(key string, value interface{}) error
+	SetMembers(key string) []interface{}
 }

--- a/redis.go
+++ b/redis.go
@@ -95,6 +95,34 @@ func (k *RedisKVStoreConnection) Set(key string, value interface{}) error {
 	return nil
 }
 
+func (k *RedisKVStoreConnection) SetAdd(key string, value interface{}) error {
+	_, err := k.Connection.Do("SADD", key, value)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *RedisKVStoreConnection) SetMembers(key string) []interface{} {
+	reply, err := k.Connection.Do("SMEMBERS", key)
+
+	if err != nil {
+		return nil
+	}
+
+	values, err := Values(reply)
+	if err != nil {
+		return nil
+	}
+	if len(values) == 0 {
+		return nil
+	}
+
+	return values
+}
+
 func (k *RedisKVStoreConnection) Delete(key string) error {
 	_, err := k.Connection.Do("DEL", key)
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+func compareStringSets(a []interface{}, b []string) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+
+	ma := make(map[string]bool)
+	for _, aa := range a {
+		s, err := String(aa)
+		if err != nil {
+			return false
+		}
+		ma[s] = true
+	}
+
+	for _, s := range b {
+		if _, ok := ma[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func TestRedis(t *testing.T) {
 	kvstore := NewRedisKVStore("127.0.0.1", 6379, "", 0)
 
@@ -26,4 +51,15 @@ func TestRedis(t *testing.T) {
 	assert.Equal(t, nil, con.Get("key"))
 
 	assert.False(t, con.Exists("key"))
+
+	// Sets
+	con.SetAdd("myset", "hello")
+	con.SetAdd("myset", "world")
+	assert.True(t, compareStringSets(con.SetMembers("myset"), []string{"hello", "world"}))
+	con.SetAdd("myset", "hello")
+	assert.True(t, compareStringSets(con.SetMembers("myset"), []string{"hello", "world"}))
+	con.SetAdd("myset", "hi")
+	assert.True(t, compareStringSets(con.SetMembers("myset"), []string{"hello", "world", "hi"}))
+	con.Delete("myset")
+	assert.True(t, con.SetMembers("myset") == nil)
 }


### PR DESCRIPTION
SetAdd - adds item to a set.
SetMembers - retrieves all items from a set.

The main question is, do you think it's a good interface for that? Maybe I should expose map[string]bool directly? But I wanted to keep it generic, which isn't pretty in Go.
